### PR TITLE
added MOM6/src/framework/MOM_ANN.F90

### DIFF
--- a/external/mom6/mom6_files.cmake
+++ b/external/mom6/mom6_files.cmake
@@ -126,6 +126,7 @@ list(APPEND mom6_src_files
   MOM6/src/equation_of_state/TEOS10/gsw_t_freezing_poly.f90
   MOM6/src/equation_of_state/TEOS10/gsw_t_from_ct.f90
 
+  MOM6/src/framework/MOM_ANN.F90
   MOM6/src/framework/MOM_array_transform.F90
   MOM6/src/framework/MOM_checksums.F90
   MOM6/src/framework/MOM_coms.F90


### PR DESCRIPTION
## Description
Updating to a more recent version of MOM6 requires adding `MOM6/src/framework/MOM_ANN.F90` to the cmake list (see @jiandewang 's issue [GDASApp/issues/2067](https://github.com/NOAA-EMC/GDASApp/issues/2067).

## Testing
The `soca` ctests are deleted in `dev/emc`, testing was done using a relevant subset of the GDASApp ctests which have enough coverage to insure tat the proposed change is fine. 

```bash
[ufe01 /scratch3/NCEPDEV/.../build/gdas-utils [HEAD]] $ ctest 
Test project /scratch3/NCEPDEV/da/Guillaume.Vernieres/prs/gw-socaupdate/sorc/gdas.cd/build/gdas-utils
    Start 1: test_gdasapp_utils_incrhandler
1/9 Test #1: test_gdasapp_utils_incrhandler ...................   Passed    4.24 sec
    Start 2: test_gdasapp_utils_incrhandler_8pes
2/9 Test #2: test_gdasapp_utils_incrhandler_8pes ..............   Passed    4.27 sec
    Start 3: test_gdasapp_utils_incrhandler_reproducibility
3/9 Test #3: test_gdasapp_utils_incrhandler_reproducibility ...   Passed    0.04 sec
    Start 4: test_gdasapp_utils_hybridweights
4/9 Test #4: test_gdasapp_utils_hybridweights .................   Passed    2.88 sec
    Start 5: test_gdasapp_utils_setcorscales
5/9 Test #5: test_gdasapp_utils_setcorscales ..................   Passed    2.95 sec
    Start 6: test_gdasapp_utils_diagb
6/9 Test #6: test_gdasapp_utils_diagb .........................   Passed    5.20 sec
    Start 7: test_gdasapp_utils_enshandler
7/9 Test #7: test_gdasapp_utils_enshandler ....................   Passed    2.94 sec
    Start 8: test_gdasapp_utils_socatofv3
8/9 Test #8: test_gdasapp_utils_socatofv3 .....................   Passed    7.00 sec
    Start 9: test_gdasapp_utils_diagnostics
9/9 Test #9: test_gdasapp_utils_diagnostics ...................   Passed    2.85 sec

100% tests passed, 0 tests failed out of 9

Total Test time (real) =  32.41 sec
```

